### PR TITLE
Fix for Whitespace contradicts operator precedence

### DIFF
--- a/library/src/main/java/com/silverpine/uu/core/UUInt.kt
+++ b/library/src/main/java/com/silverpine/uu/core/UUInt.kt
@@ -23,5 +23,5 @@ val Int.uuPx: Int
  */
 fun Int.uuIsBitSet(mask: Int): Boolean
 {
-    return this and mask == mask
+    return (this and mask) == mask
 }


### PR DESCRIPTION
To fix the problem, we need to make the operator precedence explicit by adding parentheses: change `this and mask == mask` to `(this and mask) == mask`. Only line 26 in the file library/src/main/java/com/silverpine/uu/core/UUInt.kt needs to be updated. This logical change does not affect functionality but clarifies grouping dictated by operator precedence, improving readability and maintainability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._